### PR TITLE
Fix compile warnings

### DIFF
--- a/include/concoct.h
+++ b/include/concoct.h
@@ -34,6 +34,9 @@
   static const char ARG_PREFIX = '-';
 #endif
 
+// Used to flag unused variables and silence compiler warnings
+#define UNUSED(x) (void)(x)
+
 void clean_exit(int status);
 void lex_file(const char* file_name);
 void lex_string(const char* input_string);

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -107,57 +107,9 @@ typedef enum concoct_token_type
 } ConcoctTokenType;
 
 #define CCT_KEYWORD_COUNT 23
-static const char* cct_keywords[CCT_KEYWORD_COUNT] = {
-  "break",
-  "continue",
-  "case",
-  "class",
-  "do",
-  "default",
-  "else",
-  "enum",
-  "false",
-  "for",
-  "func",
-  "goto",
-  "if",
-  "namespace",
-  "null",
-  "return",
-  "switch",
-  "super",
-  "true",
-  "use",
-  "var",
-  "while",
-  "in"
-};
+extern const char* cct_keywords[CCT_KEYWORD_COUNT];
 
-static ConcoctTokenType cct_keyword_types[CCT_KEYWORD_COUNT] = {
-  CCT_TOKEN_BREAK,
-  CCT_TOKEN_CONTINUE,
-  CCT_TOKEN_CASE,
-  CCT_TOKEN_CLASS,
-  CCT_TOKEN_DO,
-  CCT_TOKEN_DEFAULT,
-  CCT_TOKEN_ELSE,
-  CCT_TOKEN_ENUM,
-  CCT_TOKEN_FALSE,
-  CCT_TOKEN_FOR,
-  CCT_TOKEN_FUNC,
-  CCT_TOKEN_GOTO,
-  CCT_TOKEN_IF,
-  CCT_TOKEN_NAMESPACE,
-  CCT_TOKEN_NULL,
-  CCT_TOKEN_RETURN,
-  CCT_TOKEN_SWITCH,
-  CCT_TOKEN_SUPER,
-  CCT_TOKEN_TRUE,
-  CCT_TOKEN_USE,
-  CCT_TOKEN_VAR,
-  CCT_TOKEN_WHILE,
-  CCT_TOKEN_IN
-};
+extern ConcoctTokenType cct_keyword_types[CCT_KEYWORD_COUNT];
 
 typedef struct concoct_token
 {

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -66,9 +66,9 @@ static const Byte R13 = 13;
 static const Byte R14 = 14;
 static const Byte R15 = 15;
 static const Byte RS = 16;  // result
-static Opcode** IP;         // instruction pointer
-static Object** RP;         // register pointer
-static Stack** SP;          // stack pointer
+extern Opcode** IP;         // instruction pointer
+extern Object** RP;         // register pointer
+extern Stack** SP;          // stack pointer
 
 typedef enum
 {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -31,6 +31,58 @@
 #include <string.h>
 #include "lexer.h"
 
+const char* cct_keywords[CCT_KEYWORD_COUNT] = {
+  "break",
+  "continue",
+  "case",
+  "class",
+  "do",
+  "default",
+  "else",
+  "enum",
+  "false",
+  "for",
+  "func",
+  "goto",
+  "if",
+  "namespace",
+  "null",
+  "return",
+  "switch",
+  "super",
+  "true",
+  "use",
+  "var",
+  "while",
+  "in"
+};
+
+ConcoctTokenType cct_keyword_types[CCT_KEYWORD_COUNT] = {
+  CCT_TOKEN_BREAK,
+  CCT_TOKEN_CONTINUE,
+  CCT_TOKEN_CASE,
+  CCT_TOKEN_CLASS,
+  CCT_TOKEN_DO,
+  CCT_TOKEN_DEFAULT,
+  CCT_TOKEN_ELSE,
+  CCT_TOKEN_ENUM,
+  CCT_TOKEN_FALSE,
+  CCT_TOKEN_FOR,
+  CCT_TOKEN_FUNC,
+  CCT_TOKEN_GOTO,
+  CCT_TOKEN_IF,
+  CCT_TOKEN_NAMESPACE,
+  CCT_TOKEN_NULL,
+  CCT_TOKEN_RETURN,
+  CCT_TOKEN_SWITCH,
+  CCT_TOKEN_SUPER,
+  CCT_TOKEN_TRUE,
+  CCT_TOKEN_USE,
+  CCT_TOKEN_VAR,
+  CCT_TOKEN_WHILE,
+  CCT_TOKEN_IN
+};
+
 ConcoctLexer* cct_new_file_lexer(FILE* in_file)
 {
   ConcoctLexer* lexer = malloc(sizeof(ConcoctLexer));
@@ -127,6 +179,8 @@ ConcoctToken cct_next_token(ConcoctLexer* lexer)
   ConcoctTokenType type = CCT_TOKEN_ERROR;
   // How far into the text we are
   int text_index = 0;
+  // Error text
+  char* error_string = malloc(32);
   // Default to an empty string
   lexer->token_text[0] = '\0';
   // Skips whitespace and comments, repeatedly
@@ -498,17 +552,16 @@ ConcoctToken cct_next_token(ConcoctLexer* lexer)
       default:
         // This means it's some sort of unsupported character
         // We just set the text to the original text, and set the type to Error
-        char* error_string = malloc(32);
         if (error_string != NULL)
         {
-            sprintf_s(error_string, 32, "Unexpected character '%c'", lexer->next_char);
-            cct_set_error_allocated(lexer, error_string);
+          sprintf(error_string, "Unexpected character '%c'", lexer->next_char);
+          cct_set_error_allocated(lexer, error_string);
         }
         else
         {
-            cct_set_error(lexer, "Error allocating memory");
+          cct_set_error(lexer, "Error allocating memory");
         }
-        
+
         lexer->token_text[text_index++] = lexer->next_char;
         lexer->token_text[text_index] = '\0';
         cct_next_char(lexer);

--- a/src/tests/objtest.c
+++ b/src/tests/objtest.c
@@ -27,8 +27,9 @@
 
 #include <inttypes.h>
 #include <stdio.h>
-#include <stdlib.h> // rand(), srand()
-#include <time.h>   // time()
+#include <stdlib.h>  // rand(), srand()
+#include <time.h>    // time()
+#include "concoct.h"
 #include "debug.h"
 #include "memory.h"
 #include "types.h"
@@ -59,6 +60,7 @@ int main()
   srand((unsigned int)time(0));
   init_store();
   Object* objects[1024];
+  UNUSED(objects);
   for(size_t i = 0; i < 1024; i++)
   {
     printf("Object store free/capacity: %zu/%zu\n", get_store_free_slots(), get_store_capacity());

--- a/src/vm/instructions.c
+++ b/src/vm/instructions.c
@@ -25,10 +25,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <math.h>   // pow()
-#include <stdio.h>  // fprintf(), stderr
-#include <stdlib.h> // malloc()
-#include <string.h> // strcat(), strcmp()
+#include <math.h>    // pow()
+#include <stdio.h>   // fprintf(), stderr
+#include <stdlib.h>  // malloc()
+#include <string.h>  // strcat(), strcmp()
+#include "concoct.h"
 #include "memory.h"
 #include "vm/vm.h"
 
@@ -107,6 +108,7 @@ RunCode op_clr(Object** rp)
 RunCode op_cls(Stack* stack)
 {
   Object* object = NULL;
+  UNUSED(object);
   while(stack->count > 0)
     object = pop(stack);
   return RUN_SUCCESS;
@@ -170,6 +172,7 @@ RunCode op_xcg(Object** rp, Byte reg1, Byte reg2)
 // Pop
 RunCode op_pop(Stack* stack, Object* object)
 {
+  UNUSED(object);
   object = pop(stack);
   return RUN_SUCCESS;
 }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -37,6 +37,9 @@
 #include "vm/vm.h"
 
 VM vm;
+Opcode** IP;
+Object** RP;
+Stack** SP;
 
 // Initializes virtual machine
 void init_vm()
@@ -430,7 +433,7 @@ RunCode interpret()
         return RUN_ERROR;
         break;
     }
-    (*vm.ip++);
+    (vm.ip)++;
   }
   if(debug_mode)
     print_registers();


### PR DESCRIPTION
## Proposed Changes
- Add `UNUSED()` macro to flag unused variables and silence compiler warnings.
- Flag several variables as unused.
- Fix VM instruction pointer dereference and increment.
- Convert several `static` variables to `extern` and define them in the implementation (`.c`) files where they are used.
- Move `error_string` declaration from after `default` label (disallowed) to beginning of `cct_next_token()`.
- Change `sprintf_s()` (available in >=C11) to `sprintf()` since this project conforms to C99.
- Remove extraneous whitespace.